### PR TITLE
Ready for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='twittytwister',
-    version='0.1',
+    version='0.1.1',
     description='Twitter client for Twisted Python',
     author='Dustin Sallings',
     author_email='dustin@spy.net',
@@ -9,4 +9,9 @@ setup(name='twittytwister',
     license='MIT',
     platforms='any',
     packages=['twittytwister'],
+    install_requires=[
+        'oauth',
+        'simplejson',
+        'Twisted',
+    ]
 )


### PR DESCRIPTION
We are experiencing difficulties installing twitty-twister from PyPi, it fails with `ImportError: No module named twisted.python.versions`, from what I can tell due to missing Twisted dependency.

I've altered setup.py to use setuptools and install dependencies, also incremented version to 0.1.1.
Please pull and release an update to PyPi?

Tx
