### PR TITLE
Tweet Entities and User/Site streams

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
 Copyright (c) 2008-2009  Dustin Sallings <dustin@spy.net>
 Copyright (c) 2009  Diogo Ferreira <diogo@underdev.org>
+Copyright (c) 2010-2012  Ralph Meijer <ralphm@ik.nu>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/example/user_stream.py
+++ b/example/user_stream.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012  Ralph Meijer <ralphm@ik.nu>
+# See LICENSE.txt for details
+
+"""
+Print Tweets on a user's timeline in real time.
+
+This connects to the Twitter User Stream API endpoint with the given OAuth
+credentials and prints out all Tweets of the associated user and of the
+accounts the user follows. This is equivalent to the user's time line.
+
+The arguments, in order, are: consumer key, consumer secret, access token key,
+access token secret.
+"""
+
+import sys
+
+from twisted.internet import reactor
+from twisted.python import log
+
+from oauth import oauth
+
+from twittytwister import twitter
+
+def cb(entry):
+    print '%s: %s' % (entry.user.screen_name.encode('utf-8'),
+                      entry.text.encode('utf-8'))
+
+consumer = oauth.OAuthConsumer(sys.argv[1], sys.argv[2])
+token = oauth.OAuthToken(sys.argv[3], sys.argv[4])
+
+feed = twitter.TwitterFeed(consumer=consumer, token=token)
+d = feed.user(cb, {'with': 'followings'})
+
+# Exit when the connection was closed or an exception was raised.
+d.addCallback(lambda protocol: protocol.deferred)
+d.addErrback(log.err)
+d.addBoth(lambda _: reactor.stop())
+
+reactor.run()

--- a/twittytwister/streaming.py
+++ b/twittytwister/streaming.py
@@ -119,6 +119,43 @@ class TwitterObject(object):
         return obj
 
 
+    def __repr__(self):
+        bodyParts = []
+        for name in dir(self):
+            if self.SIMPLE_PROPS and name in self.SIMPLE_PROPS:
+                if hasattr(self, name):
+                    bodyParts.append("%s=%s" % (name,
+                                                repr(getattr(self, name))))
+
+            elif self.COMPLEX_PROPS and name in self.COMPLEX_PROPS:
+                if hasattr(self, name):
+                    bodyParts.append("%s=%s" % (name,
+                                                repr(getattr(self, name))))
+            elif self.LIST_PROPS and name in self.LIST_PROPS:
+                if hasattr(self, name):
+                    items = getattr(self, name)
+
+                    itemBodyParts = []
+                    for item in items:
+                        itemBodyParts.append(repr(item))
+
+                    itemBody = ',\n'.join(itemBodyParts)
+                    lines = itemBody.splitlines()
+                    itemBody = '\n    '.join(lines)
+
+                    if itemBody:
+                        itemBody = '\n    %s\n' % (itemBody,)
+
+                    bodyParts.append("%s=[%s]" % (name, itemBody))
+
+        body = ',\n'.join(bodyParts)
+        lines = body.splitlines()
+        body = '\n    '.join(lines)
+
+        result = "%s(\n    %s\n)" % (self.__class__.__name__, body)
+        return result
+
+
 
 class Indices(TwitterObject):
     """
@@ -136,6 +173,10 @@ class Indices(TwitterObject):
         except (TypeError, ValueError):
             log.err()
         return obj
+
+    def __repr__(self):
+        return "%s(start=%s, end=%s)" % (self.__class__.__name__,
+                                         self.start, self.end)
 
 
 

--- a/twittytwister/test/test_streaming.py
+++ b/twittytwister/test/test_streaming.py
@@ -309,6 +309,72 @@ class TwitterObjectTest(unittest.TestCase):
         self.assertEquals(16, hashTag.indices.end)
 
 
+    def test_repr(self):
+        data = {
+                'created_at': 'Mon Dec 06 11:46:33 +0000 2010',
+                'entities': {'hashtags': [], 'urls': [], 'user_mentions': []},
+                'id': 11748322888908800,
+                'text': 'Test #1',
+                'user': {
+                    'id': 70393696,
+                    'screen_name': 'ikdisplay',
+                    }
+                }
+        status = streaming.Status.fromDict(data)
+        result = repr(status)
+        expected = """Status(
+    created_at='Mon Dec 06 11:46:33 +0000 2010',
+    entities=Entities(
+        hashtags=[],
+        urls=[],
+        user_mentions=[]
+    ),
+    id=11748322888908800,
+    text='Test #1',
+    user=User(
+        id=70393696,
+        screen_name='ikdisplay'
+    )
+)"""
+        self.assertEqual(expected, result)
+
+
+    def test_reprIndices(self):
+        data = [6, 16]
+        indices = streaming.Indices.fromDict(data)
+        result = repr(indices)
+        expected = """Indices(start=6, end=16)"""
+        self.assertEqual(expected, result)
+
+
+    def test_reprEntities(self):
+        data = {
+            "urls": [
+                {
+                    "url": "http://t.co/0JG5Mcq",
+                    "display_url": u"blog.twitter.com/2011/05/twitte\xe2",
+                    "expanded_url": "http://blog.twitter.com/2011/05/twitter-for-mac-update.html",
+                    "indices": [
+                        84,
+                        103
+                    ]
+                }
+            ],
+        }
+        entities = streaming.Entities.fromDict(data)
+        result = repr(entities)
+        expected = """Entities(
+    urls=[
+        URL(
+            display_url=u'blog.twitter.com/2011/05/twitte\\xe2',
+            expanded_url='http://blog.twitter.com/2011/05/twitter-for-mac-update.html',
+            indices=Indices(start=84, end=103),
+            url='http://t.co/0JG5Mcq'
+        )
+    ]
+)"""
+        self.assertEqual(expected, result)
+
 
 class TestableTwitterStream(streaming.TwitterStream):
 

--- a/twittytwister/test/test_twitter.py
+++ b/twittytwister/test/test_twitter.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2010-2012  Ralph Meijer <ralphm@ik.nu>
+# See LICENSE.txt for details
+
+"""
+Tests for L{twittytwister.twitter}.
+"""
+
+from twisted.trial import unittest
+from twittytwister import twitter
+
+class TwitterFeedTest(unittest.TestCase):
+    """
+    Tests for L{twitter.TwitterFeed):
+    """
+
+    def setUp(self):
+        self.feed = twitter.TwitterFeed()
+        self.calls = []
+
+
+    def _rtfeed(self, url, delegate, args):
+        self.calls.append((url, delegate, args))
+
+
+    def test_user(self):
+        """
+        C{user} opens a Twitter User Stream.
+        """
+        self.patch(self.feed, '_rtfeed', self._rtfeed)
+        self.feed.user(None)
+        self.assertEqual(1, len(self.calls))
+        url, delegate, args = self.calls[-1]
+        self.assertEqual('https://userstream.twitter.com/2/user.json', url)
+        self.assertIdentical(None, delegate)
+        self.assertIdentical(None, args)
+
+
+    def test_userArgs(self):
+        """
+        The second argument to C{user} is a dict passed on as arguments.
+        """
+        self.patch(self.feed, '_rtfeed', self._rtfeed)
+        self.feed.user(None, {'replies': 'all'})
+        url, delegate, args = self.calls[-1]
+        self.assertEqual({'replies': 'all'}, args)

--- a/twittytwister/test/test_twitter.py
+++ b/twittytwister/test/test_twitter.py
@@ -43,3 +43,16 @@ class TwitterFeedTest(unittest.TestCase):
         self.feed.user(None, {'replies': 'all'})
         url, delegate, args = self.calls[-1]
         self.assertEqual({'replies': 'all'}, args)
+
+
+    def test_site(self):
+        """
+        C{site} opens a Twitter Site Stream.
+        """
+        self.patch(self.feed, '_rtfeed', self._rtfeed)
+        self.feed.site(None, {'follow': '6253282'})
+        self.assertEqual(1, len(self.calls))
+        url, delegate, args = self.calls[-1]
+        self.assertEqual('https://sitestream.twitter.com/2b/site.json', url)
+        self.assertIdentical(None, delegate)
+        self.assertEqual({'follow': '6253282'}, args)

--- a/twittytwister/twitter.py
+++ b/twittytwister/twitter.py
@@ -691,4 +691,22 @@ class TwitterFeed(Twitter):
                             delegate,
                             args)
 
+
+    def site(self, delegate, args):
+        """
+        Return all statuses of the specified users.
+
+        This uses the Site Stream API endpoint. The users to follow are
+        specified using the (mandatory) C{'follow'} argument in C{args}.
+        Without additional arguments it returns all statuses of the specified
+        users, in real-time.
+
+        Depending on the arguments, it can also send the statuses of the
+        accounts the users follow and/or all replies to accounts the users
+        follow.
+        """
+        return self._rtfeed('https://sitestream.twitter.com/2b/site.json',
+                            delegate,
+                            args)
+
 # vim: set expandtab:

--- a/twittytwister/twitter.py
+++ b/twittytwister/twitter.py
@@ -1,9 +1,12 @@
-#!/usr/bin/env python
+# -*- test-case-name: twittytwister.test.test_streaming -*-
+#
+# Copyright (c) 2008  Dustin Sallings <dustin@spy.net>
+# Copyright (c) 2009  Kevin Dunglas <dunglas@gmail.com>
+# Copyright (c) 2010-2012  Ralph Meijer <ralphm@ik.nu>
+# See LICENSE.txt for details
+
 """
 Twisted Twitter interface.
-
-Copyright (c) 2008  Dustin Sallings <dustin@spy.net>
-Copyright (c) 2009  Kevin Dunglas <dunglas@gmail.com>
 """
 
 import base64
@@ -527,6 +530,8 @@ class Twitter(object):
         return self.__postMultipart('/account/update_profile_image.xml',
                                     files=(('image', filename, image),))
 
+
+
 class TwitterFeed(Twitter):
     """
     Realtime feed handling class.
@@ -537,6 +542,11 @@ class TwitterFeed(Twitter):
         def exampleDelegate(entry):
             print entry.text
 
+    Several methods take an optional C{args} parameter with a dictionary
+    of request arguments that are passed along in the request. See
+    U{https://dev.twitter.com/docs/streaming-apis/parameters} for a
+    description of the parameters and for which methods they apply.
+
     @cvar protocol: The protocol class to instantiate and deliver the response
         body to. Defaults to L{streaming.TwitterStream}.
     """
@@ -546,6 +556,7 @@ class TwitterFeed(Twitter):
     def __init__(self, *args, **kwargs):
         Twitter.__init__(self, *args, **kwargs)
         self.agent = client.Agent(reactor)
+
 
     def _rtfeed(self, url, delegate, args):
         def cb(response):
@@ -655,7 +666,7 @@ class TwitterFeed(Twitter):
         """
         Returns public statuses matching a set of keywords.
 
-        Note that the old API method 'follow' is deprecated. This method is
+        Note that the old API method 'track' is deprecated. This method is
         backwards compatible and provides a shorthand to L{filter}. The actual
         allowed number of keywords in C{terms} depends on the access level of
         the used account.
@@ -663,18 +674,19 @@ class TwitterFeed(Twitter):
         return self.filter(delegate, {'track': ','.join(terms)})
 
 
-    def user(self, delegate, withFollowings=False, allReplies=False,
-                   follow=None, terms=None):
-        args = {}
-        if withFollowings:
-            args['with'] = 'followings'
-        if allReplies:
-            args['replies'] = 'all'
-        if follow:
-            args['follow'] = ','.join(follow)
-        if terms:
-            args['track'] = ','.join(terms)
+    def user(self, delegate, args=None):
+        """
+        Return all statuses of the connecting user.
 
+        This uses the User Stream API endpoint. Without arguments it returns
+        all statuses of the user itself, in real-time.
+
+        Depending on the arguments, it can also send the statuses of the
+        accounts the user follows and/or all replies to accounts the user
+        follows. On top of that, it takes the same arguments as L{filter} to
+        also track certain keywords, follow additional accounts or filter by
+        location.
+        """
         return self._rtfeed('https://userstream.twitter.com/2/user.json',
                             delegate,
                             args)

--- a/twittytwister/twitter.py
+++ b/twittytwister/twitter.py
@@ -662,4 +662,21 @@ class TwitterFeed(Twitter):
         """
         return self.filter(delegate, {'track': ','.join(terms)})
 
+
+    def user(self, delegate, withFollowings=False, allReplies=False,
+                   follow=None, terms=None):
+        args = {}
+        if withFollowings:
+            args['with'] = 'followings'
+        if allReplies:
+            args['replies'] = 'all'
+        if follow:
+            args['follow'] = ','.join(follow)
+        if terms:
+            args['track'] = ','.join(terms)
+
+        return self._rtfeed('https://userstream.twitter.com/2/user.json',
+                            delegate,
+                            args)
+
 # vim: set expandtab:


### PR DESCRIPTION
I messed up the branches a bit, but this is really two different things for the Streaming API: support for Tweet Entities and support for User Streams and Site Streams (Fixes #10).
